### PR TITLE
Fixed issues in CVEfixes CVE collection pipeline

### DIFF
--- a/Code/cve_importer.py
+++ b/Code/cve_importer.py
@@ -97,6 +97,11 @@ def preprocess_jsons(df_in):
     # renaming the column names
     df_cve.columns = [rename_columns(i) for i in df_cve.columns]
 
+    # Check and add columns if they are not present in the dataframe
+    for col in ordered_cve_columns:
+        if col not in df_cve.columns:
+            df_cve[col] = ""
+
     # ordering the cve columns
     df_cve = df_cve[ordered_cve_columns]
 

--- a/Code/extract_cwe_record.py
+++ b/Code/extract_cwe_record.py
@@ -23,7 +23,7 @@ def extract_cwe():
     cwe_doc = sorted(Path(cf.DATA_PATH).glob('cwec_*.xml'))
     if len(cwe_doc) > 0:
         cf.logger.info('Reusing the CWE XML file that is already in the directory')
-        xtree = et.parse(cf.DATA_PATH + cwe_doc[-1])
+        xtree = et.parse(cwe_doc[-1])
     else:
         cwe_url = 'https://cwe.mitre.org/data/xml/cwec_latest.xml.zip'
         cwe_zip = ZipFile(BytesIO(urlopen(cwe_url).read()))


### PR DESCRIPTION
Hi,

First of all I want to thank you for your developing this amazing tool, I recently used it to collect latest CVEs data for my project.

While using it I ran into the following issues and created a fix for them:

1. Before ordering df_cve in `cve_importer.py - preprocess_jsons(df_in)` the code does not check if all columns exist, which leads to keyerrors
2. In case you are reusing CWE XML file the code prepends DATA_PATH again to the cwe_doc in `extract_cwe_record.py - extract_cwe()`, which creates a wrong path leading to a path error

One more thing I wanted to mention is that this [issue](https://github.com/secureIT-project/CVEfixes/issues/11#issuecomment-1478099228) mentions two hacks to deal with CWE-1026 issue, `"hack" to get things running is to manually update your https://github.com/advisories/GHSA-9895-g6x5-xwcp to use CWE-1027, the first subtype in the view, or to add 1026 as a member of itself in cwec_v4.10.xml under View ID="1026".`. For these two hacks the second one, about adding 1026 as a member to itself, does not work and gave the same error, but the first one solved the issue.